### PR TITLE
Symfony to beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
-        "open-telemetry/opentelemetry": "0.0.15",
+        "open-telemetry/opentelemetry": "^1.0.0",
         "php-http/discovery": "^1.14",
         "php-http/message": "^1.12"
     },

--- a/src/OtelSdkBundle/Trace/ExporterFactory.php
+++ b/src/OtelSdkBundle/Trace/ExporterFactory.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Symfony\OtelSdkBundle\Trace;
 
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Symfony\OtelSdkBundle\Factory;
 use Psr\Http\Client\ClientInterface;
@@ -31,6 +32,12 @@ class ExporterFactory implements Factory\GenericFactoryInterface
     public function build(array $options = []): SpanExporterInterface
     {
         try {
+            // workaround Configuration being out of step with reality
+            if (isset($options['url']) && !isset($options['transport'])) {
+                $options['transport'] = PsrTransportFactory::discover()->create($options['url'], 'application/json');
+                unset($options['url']);
+            }
+
             $res = $this->doBuild($options);
             if (!$res instanceof SpanExporterInterface) {
                 throw new RuntimeException(


### PR DESCRIPTION
@brettmc - regarding https://github.com/opentelemetry-php/contrib-sdk-bundle/releases/tag/0.0.18

I managed to get the package to work with the beta release in my particular case by removing references to Jaeger (in favour of the closely compatible Zipkin) and tweaking the configuration loader for Exporters.

I know it's a bit of a hack and probably needs the configuration to be redefined to be compatible with the underlying changes, but was this the only thing blocking compatibility with the beta release or are there other issues?

Does the alternative StreamTransport also need to be supported or is hardcoding the package to the PsrTransport as I've done here sufficient?