### PR TITLE
Apply compatibility tweaks for symfony-instrumentation-bundle compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,11 @@
         }
     },
     "require-dev": {
+        "ext-grpc": "*",
         "composer/xdebug-handler": "^2.0",
         "dg/bypass-finals": "^1.3",
-        "ext-grpc": "*",
         "friendsofphp/php-cs-fixer": "^3.0",
+        "google/protobuf": "^3.23",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2.0@RC",
         "kriswallsmith/buzz": "^1.2",
@@ -41,7 +42,9 @@
         "mikey179/vfsstream": "^1.6",
         "nyholm/psr7": "^1.4",
         "open-telemetry/dev-tools": "dev-main",
+        "open-telemetry/sdk": "^1",
         "phan/phan": "^4.1 || ^5",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpstan/phpstan-symfony": "^1.1",
@@ -54,8 +57,7 @@
         "symfony/polyfill-php80": "^1.16",
         "symfony/proxy-manager-bridge": "^4.4|^5.3|^6.0",
         "symfony/yaml": "^4.4|^5.3|^6.0",
-        "vimeo/psalm": "^4.0",
-        "open-telemetry/sdk": "^1"
+        "vimeo/psalm": "^4.0"
     },
     "suggest": {
         "symfony/config": "Needed to use otel-sdk-bundle",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,7 +38,6 @@
         <ini name="display_startup_errors" value="On" />
         <ini name="error_reporting" value="E_ALL" />
     </php>
-    <!--
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Unit</directory>
@@ -47,5 +46,4 @@
             <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
-    -->
 </phpunit>

--- a/src/OtelSdkBundle/Debug/TraceableSpanProcessor.php
+++ b/src/OtelSdkBundle/Debug/TraceableSpanProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Symfony\OtelSdkBundle\Debug;
 
-use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Trace\ReadableSpanInterface;
 use OpenTelemetry\SDK\Trace\ReadWriteSpanInterface;
@@ -33,7 +33,7 @@ class TraceableSpanProcessor implements SpanProcessorInterface
         }
     }
 
-    public function onStart(ReadWriteSpanInterface $span, Context $parentContext): void
+    public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
         $this->dataCollector->collectedSpans[$span->getContext()->getSpanId()] = $span;
         $this->spanProcessor->onStart($span, $parentContext);

--- a/src/OtelSdkBundle/DependencyInjection/ConfigMappings.php
+++ b/src/OtelSdkBundle/DependencyInjection/ConfigMappings.php
@@ -26,4 +26,9 @@ interface ConfigMappings
         Configuration::OTLP_GRPC_EXPORTER => SpanExporters::OTLP_GRPC,
         Configuration::ZIPKIN_TO_NEWRELIC_EXPORTER => SpanExporters::ZIPKIN_TO_NEWRELIC,
     ];
+    public const SPAN_EXPORTER_FACTORIES = [
+        Configuration::ZIPKIN_EXPORTER_FACTORY => SpanExporterFactories::ZIPKIN,
+        Configuration::NEWRELIC_EXPORTER_FACTORY => SpanExporterFactories::NEWRELIC,
+        Configuration::OTLP_EXPORTER_FACTORY => SpanExporterFactories::OTLP,
+    ];
 }

--- a/src/OtelSdkBundle/DependencyInjection/Configuration.php
+++ b/src/OtelSdkBundle/DependencyInjection/Configuration.php
@@ -26,7 +26,6 @@ class Configuration implements ConfigurationInterface
     public const CUSTOM_TYPE = 'custom';
     public const DEFAULT_TYPE = 'default';
     public const CLASS_NODE = 'class';
-    public const FACTORY_NODE = 'factory';
     public const ID_NODE = 'id';
     public const RESOURCE_NODE = 'resource';
     public const LIMITS_NODE = 'limits';
@@ -96,16 +95,8 @@ class Configuration implements ConfigurationInterface
     public const OTLP_HTTP_EXPORTER = 'otlphttp';
     public const OTLP_GRPC_EXPORTER = 'otlpgrpc';
     public const ZIPKIN_TO_NEWRELIC_EXPORTER = 'zipkintonewrelic';
-    // public const EXPORTERS_NODE_VALUES = [
-    //     self::JAEGER_EXPORTER,
-    //     self::ZIPKIN_EXPORTER,
-    //     self::NEWRELIC_EXPORTER,
-    //     self::OTLP_HTTP_EXPORTER,
-    //     self::OTLP_GRPC_EXPORTER,
-    //     self::ZIPKIN_TO_NEWRELIC_EXPORTER,
-    // ];
 
-    // Using factories instead
+    // Declare Exporter Factories
     public const ZIPKIN_EXPORTER_FACTORY = 'zipkin';
     public const NEWRELIC_EXPORTER_FACTORY = 'newrelic';
     public const OTLP_EXPORTER_FACTORY = 'otlp';

--- a/src/OtelSdkBundle/DependencyInjection/Configuration.php
+++ b/src/OtelSdkBundle/DependencyInjection/Configuration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
 
 use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
-use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Symfony\OtelSdkBundle\Util\ExporterDsnParser;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;

--- a/src/OtelSdkBundle/DependencyInjection/Configuration.php
+++ b/src/OtelSdkBundle/DependencyInjection/Configuration.php
@@ -100,7 +100,7 @@ class Configuration implements ConfigurationInterface
     public const ZIPKIN_EXPORTER_FACTORY = 'zipkin';
     public const NEWRELIC_EXPORTER_FACTORY = 'newrelic';
     public const OTLP_EXPORTER_FACTORY = 'otlp';
-    public const EXPORTERS_NODE_VALUES = [
+    public const EXPORTER_FACTORY_VALUES = [
         self::ZIPKIN_EXPORTER_FACTORY,
         self::NEWRELIC_EXPORTER_FACTORY,
         self::OTLP_EXPORTER_FACTORY,
@@ -498,19 +498,19 @@ class Configuration implements ConfigurationInterface
 
     private static function validateCustomExporterConfig(array $config)
     {
-        // custom exporters need class or id provided.
+        // custom exporter factories need class or id provided.
         self::validateCustomService(
             $config,
             self::EXPORTER_HR
         );
 
         if (isset($config[self::CLASS_NODE])) {
-            // custom exporters classes need to be a valid FQCN
+            // custom exporter factory classes need to be valid FQCNs
             self::validateCustomClass(
                 $config[self::CLASS_NODE],
                 self::EXPORTER_HR
             );
-            // custom span exporters need to implement OpenTelemetry\SDK\Trace\SpanExporterInterface
+            // custom span exporter factories need to implement OpenTelemetry\SDK\Trace\SpanExporterFactoryInterface
             self::validateCustomClassImplements(
                 $config[self::CLASS_NODE],
                 SpanExporterFactoryInterface::class,

--- a/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
+++ b/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
@@ -281,13 +281,17 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
     {
         $id = $this->createExporterId($exporterKey);
         $options = $this->normalizeExporterOptions($config);
+       # echo "** \$exporterKey: $exporterKey - ".var_export($config, true)."\n";
         $definition =  self::createDefinition($this->resolveExporterClass($config))
             ->setFactory(
-                $this->createValidatedReference(
-                    $this->registerExporterFactoryDefinition($exporterKey, $config)
-                )
-            )
-            ->setArguments([$options]);
+                [
+                    $this->createValidatedReference(
+                        $this->registerExporterFactoryDefinition($exporterKey, $config)
+                    ),
+                    'create'
+                ]
+            );
+            //->setArguments([$options]);
 
         $this->registerService($id, $definition, false);
 
@@ -390,8 +394,10 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
      */
     private function createExporterFactoryDefinition(string $exporterClass): Definition
     {
-        $definition = self::createDefinition(ExporterFactory::class);
-        $definition->setArguments([$exporterClass]);
+        //die('exporterClass: ' . $exporterClass);
+       # $definition = self::createDefinition(ExporterFactory::class);
+       # $definition->setArguments([$exporterClass]);
+        $definition = self::createDefinition($exporterClass);
 
         return $definition;
     }
@@ -403,9 +409,11 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
     private function resolveExporterClass(array $config): string
     {
         if (in_array($config[Conf::TYPE_NODE], Conf::EXPORTERS_NODE_VALUES, true)) {
-            return ConfigMappings::SPAN_EXPORTERS[
-            $config[Conf::TYPE_NODE]
+            $f = ConfigMappings::SPAN_EXPORTER_FACTORIES[
+                $config[Conf::TYPE_NODE]
             ];
+           # echo " -- " . ($f) . "\n";
+            return $f;
         }
         if ($config[Conf::TYPE_NODE] === Conf::CUSTOM_TYPE) {
             if (isset($config[Conf::CLASS_NODE])) {

--- a/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
+++ b/src/OtelSdkBundle/DependencyInjection/OtelSdkExtension.php
@@ -411,18 +411,14 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
     {
         try {
             if ($resolvedInstance = Registry::spanExporterFactory($config[Conf::TYPE_NODE])) {
-                $f = $resolvedInstance::class;
-              #  echo " -- " . ($f) . "\n";
-                return $f;
+                return $resolvedInstance::class;
             }
         } catch (RuntimeException) {
         }
-        if (in_array($config[Conf::TYPE_NODE], Conf::EXPORTERS_NODE_VALUES, true)) {
-            $f = ConfigMappings::SPAN_EXPORTER_FACTORIES[
+        if (in_array($config[Conf::TYPE_NODE], Conf::EXPORTER_FACTORY_VALUES, true)) {
+            return ConfigMappings::SPAN_EXPORTER_FACTORIES[
                 $config[Conf::TYPE_NODE]
             ];
-           # echo " -- " . ($f) . "\n";
-            return $f;
         }
         if ($config[Conf::TYPE_NODE] === Conf::CUSTOM_TYPE) {
             if (isset($config[Conf::CLASS_NODE])) {
@@ -434,7 +430,7 @@ class OtelSdkExtension extends Extension implements LoggerAwareInterface
             sprintf(
                 'Exporter must either be one of the following types: %s, %s ',
                 Conf::CUSTOM_TYPE,
-                implode(', ', Conf::EXPORTERS_NODE_VALUES)
+                implode(', ', Conf::EXPORTER_FACTORY_VALUES)
             )
         );
     }

--- a/src/OtelSdkBundle/DependencyInjection/SpanExporterFactories.php
+++ b/src/OtelSdkBundle/DependencyInjection/SpanExporterFactories.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection;
+
+use OpenTelemetry\Contrib;
+
+interface SpanExporterFactories
+{
+    public const ZIPKIN = Contrib\Zipkin\SpanExporterFactory::class;
+    public const NEWRELIC = Contrib\Newrelic\SpanExporterFactory::class;
+    public const OTLP = Contrib\Otlp\SpanExporterFactory::class;
+    public const SPAN_EXPORTER_FACTORIES = [
+        self::ZIPKIN,
+        self::NEWRELIC,
+        self::OTLP,
+    ];
+    public const NAMESPACE = 'OpenTelemetry\SDK\Trace\SpanExporter';
+}

--- a/src/OtelSdkBundle/Trace/ExporterFactory.php
+++ b/src/OtelSdkBundle/Trace/ExporterFactory.php
@@ -6,6 +6,9 @@ namespace OpenTelemetry\Symfony\OtelSdkBundle\Trace;
 
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use OpenTelemetry\SDK\Common\Export\Http\PsrTransport;
+use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
+use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Symfony\OtelSdkBundle\Factory;
 use Psr\Http\Client\ClientInterface;
@@ -29,6 +32,8 @@ class ExporterFactory implements Factory\GenericFactoryInterface
         self::NAME_PARAM => 'service_name',
     ];
 
+    private string $currentUrl;
+
     use Factory\GenericFactoryTrait;
 
     public function build(array $options = []): SpanExporterInterface
@@ -37,7 +42,11 @@ class ExporterFactory implements Factory\GenericFactoryInterface
             $res = $this->doBuild($options);
             if (!$res instanceof SpanExporterInterface) {
                 throw new RuntimeException(
-                    sprintf('Built object is not an instance of %s', SpanExporterInterface::class)
+                    sprintf(
+                        'Built object (%s) is not an instance of %s',
+                        get_class($res),
+                        SpanExporterInterface::class
+                    )
                 );
             }
 

--- a/src/OtelSdkBundle/Trace/ExporterFactory.php
+++ b/src/OtelSdkBundle/Trace/ExporterFactory.php
@@ -6,9 +6,6 @@ namespace OpenTelemetry\Symfony\OtelSdkBundle\Trace;
 
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
-use OpenTelemetry\SDK\Common\Export\Http\PsrTransport;
-use OpenTelemetry\SDK\Common\Export\Http\PsrTransportFactory;
-use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Symfony\OtelSdkBundle\Factory;
 use Psr\Http\Client\ClientInterface;

--- a/src/OtelSdkBundle/Trace/ExporterFactory.php
+++ b/src/OtelSdkBundle/Trace/ExporterFactory.php
@@ -29,8 +29,6 @@ class ExporterFactory implements Factory\GenericFactoryInterface
         self::NAME_PARAM => 'service_name',
     ];
 
-    private string $currentUrl;
-
     use Factory\GenericFactoryTrait;
 
     public function build(array $options = []): SpanExporterInterface

--- a/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
+++ b/tests/Integration/OtelSdkBundle/DependencyInjection/OtelSdkExtensionTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\DependencyInjection;
 
 use Exception;
+use OpenTelemetry\Contrib\Newrelic\SpanExporterFactory as NewrelicSpanExporterFactory;
+use OpenTelemetry\Contrib\Zipkin\SpanExporterFactory as ZipkinSpanExporterFactory;
 use OpenTelemetry\SDK;
 use OpenTelemetry\SDK\Common\Attribute\Attributes;
 use OpenTelemetry\SDK\Common\Time\SystemClock;
@@ -13,10 +15,10 @@ use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\OtelSdkExtension;
 use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Parameters;
 use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\Samplers;
 use OpenTelemetry\Symfony\OtelSdkBundle\DependencyInjection\SpanProcessors;
-use OpenTelemetry\Symfony\OtelSdkBundle\Trace\ExporterFactory;
 use OpenTelemetry\Symfony\OtelSdkBundle\Util\ConfigHelper;
 use OpenTelemetry\Symfony\OtelSdkBundle\Util\ServiceHelper;
 use OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+use OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory as MockSpanExporterFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -234,20 +236,16 @@ class OtelSdkExtensionTest extends TestCase
             $processors[0]
         );
         $this->assertIsReferenceForClass(
-            SpanProcessors::DEFAULT,
+            SpanProcessors::SIMPLE,
             $processors[1]
         );
         $this->assertIsReferenceForClass(
-            SpanProcessors::SIMPLE,
+            Mock\SpanProcessor::class,
             $processors[2]
         );
         $this->assertIsReferenceForClass(
             Mock\SpanProcessor::class,
             $processors[3]
-        );
-        $this->assertIsReferenceForClass(
-            Mock\SpanProcessor::class,
-            $processors[4]
         );
 
         // Assert clock is set as argument for batch processors
@@ -291,10 +289,6 @@ class OtelSdkExtensionTest extends TestCase
             SpanProcessors::TRACEABLE,
             $processors[3]
         );
-        $this->assertIsReferenceForClass(
-            SpanProcessors::TRACEABLE,
-            $processors[4]
-        );
     }
 
     /**
@@ -317,19 +311,38 @@ class OtelSdkExtensionTest extends TestCase
         $exporters = [];
         $processorReferences = $this->getDefinitionByClass(SDK\Trace\TracerProvider::class)
             ->getArgument(0);
-        foreach ($processorReferences as $reference) {
+        foreach ($processorReferences as $index => $reference) {
             $processor = $this->container->getDefinition((string) $reference);
             $exporterRef = $processor->getArgument(0);
             $this->assertIsReference($exporterRef);
             $exporter = $exporters[(string) $exporterRef] = $this->getContainer()->getDefinition((string) $exporterRef);
 
             if ((string) $exporterRef !== self::CUSTOM_EXPORTER_ID) {
+                switch ($reference) {
+                    default:
+                        $expectClass = null;
+                        break;
+
+                    case 'open_telemetry.sdk.trace.span_processor.default.exporter1':
+                        $expectClass = ZipkinSpanExporterFactory::class;
+                        break;
+
+                    case 'open_telemetry.sdk.trace.span_processor.simple.exporter2':
+                        $expectClass = NewrelicSpanExporterFactory::class;
+                        break;
+
+                    case 'open_telemetry.sdk.trace.span_processor.default.exporter3':
+                        $expectClass = MockSpanExporterFactory::class;
+                        break;
+                }
+
                 $this->assertIsReference(
                     $exporter->getFactory()[0],
                 );
                 $this->assertIsReferenceForClass(
-                    ExporterFactory::class,
-                    $exporter->getFactory()[0]
+                    $expectClass,
+                    $exporter->getFactory()[0],
+                    'processor index ' . $index . ' reference ' . $reference
                 );
             }
         }
@@ -337,44 +350,6 @@ class OtelSdkExtensionTest extends TestCase
         $this->assertEquals(
             $exporterIds,
             array_keys($exporters)
-        );
-
-        $this->assertEquals(
-            [
-                'url' => 'http://zipkinhost:1234/path',
-                'service_name' => 'foo',
-            ],
-            $exporters['open_telemetry.sdk.trace.span_exporter.exporter1']
-                ->getArgument(0)
-        );
-
-        $this->assertEquals(
-            [
-                'name' => 'foo',
-                'url' => 'https://foo:bar@jaegerhost:1234/path/to/endpoint',
-                'service_name' => 'foo',
-            ],
-            $exporters['open_telemetry.sdk.trace.span_exporter.exporter2']
-                ->getArgument(0)
-        );
-
-        $this->assertEquals(
-            [
-                'license_key' => 'abcde',
-                'url' => 'http://newrelichost:1234/path',
-                'service_name' => 'foo',
-            ],
-            $exporters['open_telemetry.sdk.trace.span_exporter.exporter3']
-                ->getArgument(0)
-        );
-
-        $this->assertEquals(
-            [
-                'log_file' => '/tmp/otel/exporter.log',
-                'service_name' => 'foo',
-            ],
-            $exporters['open_telemetry.sdk.trace.span_exporter.exporter4']
-                ->getArgument(0)
         );
     }
 
@@ -403,11 +378,12 @@ class OtelSdkExtensionTest extends TestCase
         );
     }
 
-    private function assertIsReferenceForClass(string $class, Reference $reference): void
+    private function assertIsReferenceForClass(string $class, Reference $reference, string $message = ''): void
     {
         $this->assertSame(
             $class,
-            $this->getClassFromReference($reference)
+            $this->getClassFromReference($reference),
+            $message
         );
     }
 

--- a/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml
+++ b/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/config.yaml
@@ -7,24 +7,17 @@ trace:
   exporters:
     # dsn example
     exporter1: zipkin+http://zipkinhost:1234/path
-    # dsn key example
-    exporter2:
-      dsn: jaeger+https://foo:bar@jaegerhost:1234/path/to/endpoint?name=foo
     # parameter example
-    exporter3:
+    exporter2:
       type: newrelic
       processor: simple
       url: http://newrelichost:1234/path
-      options:
-        license_key: abcde
     # custom exporter referenced via class
-    exporter4:
+    exporter3:
       type: custom
       processor: default
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporter
-      options:
-        log_file: /tmp/otel/exporter.log
-    exporter5:
+      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+    exporter4:
       type: custom
       processor: batch
       id: "@my_custom_exporter"

--- a/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/expected.yaml
+++ b/tests/Integration/OtelSdkBundle/DependencyInjection/config/exporters/expected.yaml
@@ -11,24 +11,16 @@ trace:
       url: http://zipkinhost:1234/path
       options: [ ]
     exporter2:
-      type: jaeger
-      url: https://foo:bar@jaegerhost:1234/path/to/endpoint
-      processor: default
-      options:
-        name: foo
-    exporter3:
       type: newrelic
       processor: simple
       url: http://newrelichost:1234/path
-      options:
-        license_key: abcde
-    exporter4:
+      options: [ ]
+    exporter3:
       type: custom
       processor: default
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporter
-      options:
-        log_file: /tmp/otel/exporter.log
-    exporter5:
+      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      options: [ ]
+    exporter4:
       type: custom
       processor: batch
       id: "@my_custom_exporter"

--- a/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/config.yaml
+++ b/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/config.yaml
@@ -57,24 +57,17 @@ trace:
   exporters:
     # dsn example
     exporter1: zipkin+http://zipkinhost:1234/path
-    # dsn key example
-    exporter2:
-      dsn: jaeger+https://foo:bar@jaegerhost:1234/path/to/endpoint?name=foo
     # parameter example
-    exporter3:
+    exporter2:
       type: newrelic
       processor: simple
       url: http://newrelichost:1234/path
-      options:
-        license_key: abcde
     # custom exporter referenced via class
-    exporter4:
+    exporter3:
       type: custom
       processor: processor4
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporter
-      options:
-        log_file: /tmp/otel/exporter.log
-    exporter5:
+      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+    exporter4:
       type: custom
       processor: processor5
       id: "@my_custom_exporter"

--- a/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/expected.yaml
+++ b/tests/Integration/OtelSdkBundle/DependencyInjection/config/full/expected.yaml
@@ -73,24 +73,16 @@ trace:
       url: http://zipkinhost:1234/path
       options: []
     exporter2:
-      type: jaeger
-      url: https://foo:bar@jaegerhost:1234/path/to/endpoint
-      processor: default
-      options:
-        name: foo
-    exporter3:
       type: newrelic
       processor: simple
       url: http://newrelichost:1234/path
-      options:
-        license_key: abcde
-    exporter4:
+      options: []
+    exporter3:
       type: custom
       processor: processor4
-      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporter
-      options:
-        log_file: /tmp/otel/exporter.log
-    exporter5:
+      class: OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock\SpanExporterFactory
+      options: []
+    exporter4:
       type: custom
       processor: processor5
       id: "@my_custom_exporter"

--- a/tests/Integration/OtelSdkBundle/Mock/SpanExporterFactory.php
+++ b/tests/Integration/OtelSdkBundle/Mock/SpanExporterFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Symfony\Integration\OtelSdkBundle\Mock;
+
+use OpenTelemetry\SDK\Trace\SpanExporter\SpanExporterFactoryInterface;
+use OpenTelemetry\SDK\Trace\SpanExporterInterface;
+
+class SpanExporterFactory implements SpanExporterFactoryInterface
+{
+    public function create(): SpanExporterInterface
+    {
+        return new SpanExporter();
+    }
+
+    public function build(array $options = []): SpanExporterInterface
+    {
+        return new SpanExporter();
+    }
+}

--- a/tests/Unit/OtelSdkBundle/Trace/ExporterFactoryTest.php
+++ b/tests/Unit/OtelSdkBundle/Trace/ExporterFactoryTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace OpenTelemetry\Tests\Symfony\Unit\OtelSdkBundle\Trace;
 
 use OpenTelemetry\Contrib;
+use OpenTelemetry\SDK\Common\Export\TransportInterface;
 use OpenTelemetry\SDK\Common\Future\CancellationInterface;
 use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
 use OpenTelemetry\Symfony\OtelSdkBundle\Trace\ExporterFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -19,6 +21,8 @@ use stdClass;
 
 class ExporterFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testBuildAllOptions()
     {
         $factory = new ExporterFactory(TestExporter::class);
@@ -97,27 +101,11 @@ class ExporterFactoryTest extends TestCase
         $factory = new ExporterFactory(Contrib\Zipkin\Exporter::class);
 
         $exporter = $factory->build([
-            'name' => 'foo',
-            'endpoint_url' => 'http://localhost:1234/path',
+            'transport' => $this->prophesize(TransportInterface::class)->reveal(),
         ]);
 
         $this->assertInstanceOf(
             Contrib\Zipkin\Exporter::class,
-            $exporter
-        );
-    }
-
-    public function testBuildJaeger()
-    {
-        $factory = new ExporterFactory(Contrib\Jaeger\Exporter::class);
-
-        $exporter = $factory->build([
-            'name' => 'foo',
-            'endpoint_url' => 'http://localhost:1234/path',
-        ]);
-
-        $this->assertInstanceOf(
-            Contrib\Jaeger\Exporter::class,
             $exporter
         );
     }
@@ -127,9 +115,8 @@ class ExporterFactoryTest extends TestCase
         $factory = new ExporterFactory(Contrib\Newrelic\Exporter::class);
 
         $exporter = $factory->build([
-            'name' => 'foo',
             'endpoint_url' => 'http://localhost:1234/path',
-            'license_key' => 'gadouzdSD',
+            'transport' => $this->prophesize(TransportInterface::class)->reveal(),
         ]);
 
         $this->assertInstanceOf(
@@ -138,44 +125,18 @@ class ExporterFactoryTest extends TestCase
         );
     }
 
-    public function testBuildOtlpGrpc()
-    {
-        $factory = new ExporterFactory(Contrib\OtlpGrpc\Exporter::class);
-
-        $exporter = $factory->build([
-            'endpoint_url' => 'http://localhost:1234/path',
-        ]);
-
-        $this->assertInstanceOf(
-            Contrib\OtlpGrpc\Exporter::class,
-            $exporter
-        );
-    }
-
     public function testBuildOtlpHttp()
     {
-        $factory = new ExporterFactory(Contrib\OtlpHttp\Exporter::class);
-
-        $exporter = $factory->build([ ]);
-
-        $this->assertInstanceOf(
-            Contrib\OtlpHttp\Exporter::class,
-            $exporter
-        );
-    }
-
-    public function testBuildZipkinToNewrelic()
-    {
-        $factory = new ExporterFactory(Contrib\ZipkinToNewrelic\Exporter::class);
+        $factory = new ExporterFactory(Contrib\Otlp\SpanExporter::class);
+        $transport = $this->prophesize(TransportInterface::class);
+        $transport->contentType()->willReturn('application/json');
 
         $exporter = $factory->build([
-            'name' => 'foo',
-            'endpoint_url' => 'http://localhost:1234/path',
-            'license_key' => 'gadouzdSD',
+            'transport' => $transport->reveal(),
         ]);
 
         $this->assertInstanceOf(
-            Contrib\ZipkinToNewrelic\Exporter::class,
+            Contrib\Otlp\SpanExporter::class,
             $exporter
         );
     }


### PR DESCRIPTION
- Change configuration to be based on SpanExporterFactory definitions instead of Exporter factories - this facilitates the injection of TransportInterfaces rather than the client etc.
- Remove references of obsolete, removed Jaeger exporters
- Updated unit and integration tests